### PR TITLE
avoid syntax error warning when loading

### DIFF
--- a/hippynn/layers/physics.py
+++ b/hippynn/layers/physics.py
@@ -206,7 +206,7 @@ class WolfScreening(AlphaScreening):
 class LocalDampingCosine(AlphaScreening):
     """ Local damping using complement of the hipnn cutoff function. ('glue-on' method)
     g =     1 if pair_dist > R_cutoff
-            1 - [cos(\pi/2 * dist * R_cutoff)]^2  otherwise
+            1 - [cos(pi/2 * dist * R_cutoff)]^2  otherwise
     """
     def __init__(self, alpha): 
         """ 


### PR DESCRIPTION
The \pi in the doc string triggers the warning
 SyntaxWarning: invalid escape sequence '\p'